### PR TITLE
Add vitest setup and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -80,6 +81,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/utils/__tests__/recurring-tasks.test.ts
+++ b/src/utils/__tests__/recurring-tasks.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { convertTo24HourFormat } from '../recurring-tasks';
+
+describe('convertTo24HourFormat', () => {
+  it('converts 1:30PM to 13:30', () => {
+    expect(convertTo24HourFormat('1:30PM')).toBe('13:30');
+  });
+
+  it('returns 24h time unchanged', () => {
+    expect(convertTo24HourFormat('14:00')).toBe('14:00');
+  });
+
+  it('handles shorthand pm', () => {
+    expect(convertTo24HourFormat('9pm')).toBe('21:00');
+  });
+
+  it('returns default for invalid time', () => {
+    expect(convertTo24HourFormat('invalid')).toBe('09:00');
+  });
+});

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,8 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    environment: "node",
+    globals: true,
+  },
 }));


### PR DESCRIPTION
## Summary
- configure Vitest test runner
- add Vitest config `tsconfig.vitest.json`
- write tests for `convertTo24HourFormat`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff507d834832c959d2fb09370581c