### PR TITLE
Fix typo in sync tasks log

### DIFF
--- a/supabase/functions/sync-tasks-to-calendar/index.ts
+++ b/supabase/functions/sync-tasks-to-calendar/index.ts
@@ -18,7 +18,7 @@ serve(async (req) => {
     const body = await req.json().catch(() => ({}));
     const { userId, taskId } = body;
     
-    console.log('db log of sync tasks to calender userId:'+ userId);
+    console.log('db log of sync tasks to calendar userId:'+ userId);
     
     if (!userId) {
       return new Response(


### PR DESCRIPTION
## Summary
- correct 'calender' typo in sync-tasks-to-calendar function

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683ff48dcbe8832c9423983fab033999