### PR TITLE
Fix time formatting edge case

### DIFF
--- a/src/utils/__tests__/recurring-tasks.test.ts
+++ b/src/utils/__tests__/recurring-tasks.test.ts
@@ -14,6 +14,10 @@ describe('convertTo24HourFormat', () => {
     expect(convertTo24HourFormat('9pm')).toBe('21:00');
   });
 
+  it('pads single digit minutes', () => {
+    expect(convertTo24HourFormat('1:5PM')).toBe('13:05');
+  });
+
   it('returns default for invalid time', () => {
     expect(convertTo24HourFormat('invalid')).toBe('09:00');
   });

--- a/src/utils/recurring-tasks.ts
+++ b/src/utils/recurring-tasks.ts
@@ -113,8 +113,8 @@ export const convertTo24HourFormat = (timeString: string): string => {
         console.log('am hour num:',hoursNum);
       }
       
-      // Format as HH:MM
-      return `${hoursNum.toString().padStart(2, '0')}:${minutes}`;
+      // Format as HH:MM, padding minutes to two digits
+      return `${hoursNum.toString().padStart(2, '0')}:${minutes.padStart(2, '0')}`;
     }
     
     // If the first pattern didn't match, try a more lenient approach


### PR DESCRIPTION
## Summary
- add a test for minutes padding
- pad minutes when converting from AM/PM format

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683ffa328884832c8f43ec574e2f1db1