### PR TITLE
Enable overdue task edit modal

### DIFF
--- a/src/components/tasks/OverdueTasksSection.tsx
+++ b/src/components/tasks/OverdueTasksSection.tsx
@@ -1,8 +1,10 @@
 
-import React from 'react';
+import React, { useState } from 'react';
 import { ChevronDown, ChevronRight, Calendar, Clock } from 'lucide-react';
 import { TaskProps } from './types';
 import TaskCard from './TaskCard';
+import CreateTaskModal from './CreateTaskModal';
+import { scheduleNextOccurrence, convertTo24HourFormat, prepareTimeForInput } from '@/utils/recurring-tasks';
 import { useTasksContext } from '@/contexts/TasksContext';
 import {
   Popover,
@@ -28,17 +30,122 @@ const OverdueTasksSection = ({
   selectedDate,
   sortOption,
 }: OverdueTasksSectionProps) => {
-  const { 
+  const {
     handleDragStart,
     handleDragOver,
     handleDragLeave,
     handleDrop,
     handleDragEnd,
-    updateTask
+    updateTask,
+    deleteTask,
+    syncTaskToCalendar
   } = useTasksContext();
+
+  const [editingTask, setEditingTask] = useState<TaskProps | null>(null);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
   // If no overdue tasks, don't render anything
   if (tasks.length === 0) return null;
+
+  const handleEditTask = (task: TaskProps) => {
+    setEditingTask(task);
+    setIsEditModalOpen(true);
+  };
+
+  const handleTaskUpdate = async (updatedTaskData: any) => {
+    if (!editingTask) return;
+
+    const taskUpdates: Partial<TaskProps> = {
+      title: updatedTaskData.title,
+      description: updatedTaskData.description || '',
+      priority: updatedTaskData.priority,
+      dueDate: new Date(updatedTaskData.dueDate),
+      completed: editingTask.completed,
+    };
+
+    if (updatedTaskData.isAllDay !== undefined) {
+      taskUpdates.isAllDay = updatedTaskData.isAllDay;
+    }
+
+    if (!updatedTaskData.isAllDay && updatedTaskData.startTime) {
+      taskUpdates.startTime = convertTo24HourFormat(updatedTaskData.startTime);
+      if (updatedTaskData.endTime) {
+        taskUpdates.endTime = convertTo24HourFormat(updatedTaskData.endTime);
+      }
+    } else {
+      taskUpdates.startTime = null;
+      taskUpdates.endTime = null;
+    }
+
+    if (updatedTaskData.recurring && updatedTaskData.recurring !== 'none') {
+      taskUpdates.recurring = {
+        frequency: updatedTaskData.recurring as 'daily' | 'weekly' | 'monthly' | 'custom',
+        customDays: updatedTaskData.selectedWeekdays || []
+      };
+
+      if (updatedTaskData.recurrenceEndType === 'date' && updatedTaskData.recurrenceEndDate) {
+        taskUpdates.recurring.endDate = new Date(updatedTaskData.recurrenceEndDate);
+      } else if (updatedTaskData.recurrenceEndType === 'after' && updatedTaskData.recurrenceCount) {
+        taskUpdates.recurring.endAfter = updatedTaskData.recurrenceCount;
+      }
+    } else {
+      taskUpdates.recurring = undefined;
+    }
+
+    await updateTask(editingTask.id, taskUpdates);
+    setIsEditModalOpen(false);
+    setEditingTask(null);
+  };
+
+  const handleTaskComplete = async (taskId: string, completed: boolean, completeForever: boolean = false) => {
+    const task = tasks.find(t => t.id === taskId);
+    if (!task) return;
+
+    if (!task.recurring || !completed || completeForever) {
+      const updatedTask = await updateTask(taskId, { completed });
+      if (updatedTask && updatedTask.googleCalendarEventId) {
+        await syncTaskToCalendar(taskId);
+      }
+      return;
+    }
+
+    await updateTask(taskId, { completed: true });
+    if (task.googleCalendarEventId) {
+      await syncTaskToCalendar(taskId);
+    }
+
+    const nextTask = await scheduleNextOccurrence(task);
+    if (nextTask) {
+      const updatedTask = await updateTask(taskId, {
+        ...nextTask,
+        dueDate: nextTask.dueDate,
+        startTime: nextTask.startTime || null,
+        endTime: nextTask.endTime || null,
+        isAllDay: nextTask.isAllDay !== undefined ? nextTask.isAllDay : true,
+        completed: false
+      });
+      if (updatedTask && updatedTask.googleCalendarEventId) {
+        await syncTaskToCalendar(taskId);
+      }
+    }
+  };
+
+  const handleTaskDelete = async (taskId: string) => {
+    const success = await deleteTask(taskId);
+    if (success) {
+      if (editingTask && editingTask.id === taskId) {
+        setIsEditModalOpen(false);
+        setEditingTask(null);
+      }
+    }
+  };
+
+  const handleTaskReschedule = async (taskId: string, newDate: Date) => {
+    const updatedTask = await updateTask(taskId, { dueDate: newDate });
+    if (updatedTask && updatedTask.googleCalendarEventId) {
+      await syncTaskToCalendar(taskId);
+    }
+  };
 
   const handleRescheduleAll = async (date: Date) => {
     // Update all overdue tasks to the selected date
@@ -118,10 +225,46 @@ const OverdueTasksSection = ({
               onDragEnd={(e) => sortOption === 'custom' && handleDragEnd(e)}
               className={sortOption === 'custom' ? 'cursor-move' : ''}
             >
-              <TaskCard task={task} />
+              <TaskCard
+                task={task}
+                onEdit={() => handleEditTask(task)}
+                onDelete={handleTaskDelete}
+                onReschedule={handleTaskReschedule}
+                onComplete={handleTaskComplete}
+              />
             </div>
           ))}
         </div>
+      )}
+
+      {editingTask && (
+        <CreateTaskModal
+          isOpen={isEditModalOpen}
+          onClose={() => {
+            setIsEditModalOpen(false);
+            setEditingTask(null);
+          }}
+          onSubmit={handleTaskUpdate}
+          editMode
+          initialData={{
+            ...editingTask,
+            dueDate: new Date(editingTask.dueDate).toISOString().split('T')[0],
+            startTime: prepareTimeForInput(editingTask.startTime),
+            endTime: prepareTimeForInput(editingTask.endTime),
+            isAllDay: editingTask.isAllDay !== undefined ? editingTask.isAllDay : true,
+            recurring: editingTask.recurring?.frequency || 'none',
+            selectedWeekdays: editingTask.recurring?.customDays || [],
+            recurrenceEndType: editingTask.recurring?.endDate
+              ? 'date'
+              : editingTask.recurring?.endAfter
+                ? 'after'
+                : 'never',
+            recurrenceEndDate: editingTask.recurring?.endDate
+              ? new Date(editingTask.recurring.endDate).toISOString().split('T')[0]
+              : '',
+            recurrenceCount: editingTask.recurring?.endAfter || 5,
+          }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- import CreateTaskModal and recurring utilities into OverdueTasksSection
- implement editing handlers mirroring TaskSection
- update TaskCard props to allow edits, deletion, reschedule and completion
- render CreateTaskModal when editing a task

## Testing
- `npm test`
- `npm run lint` *(fails: prefer-const and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840007c47e0832c820752d773ee9cd8