### PR TITLE
Fix task creation visibility and calendar update

### DIFF
--- a/src/hooks/use-task-operations.tsx
+++ b/src/hooks/use-task-operations.tsx
@@ -456,7 +456,7 @@ export const useTaskOperations = (user: any) => {
               }
             }
           );
-          
+
           if (syncError) {
             console.error('Error syncing task completion to calendar:', syncError);
           } else {
@@ -464,6 +464,33 @@ export const useTaskOperations = (user: any) => {
           }
         } catch (syncErr) {
           console.error('Exception syncing task completion to calendar:', syncErr);
+        }
+      }
+
+      // If rescheduling-related fields changed and the task has a calendar event, sync it
+      if (
+        (updates.dueDate !== undefined || updates.startTime !== undefined || updates.endTime !== undefined) &&
+        existingTask?.google_calendar_event_id &&
+        existingTask?.google_calendar_id
+      ) {
+        try {
+          const { data: syncResult, error: syncError } = await supabase.functions.invoke(
+            'sync-tasks-to-calendar',
+            {
+              body: {
+                userId: user.id,
+                taskId: id
+              }
+            }
+          );
+
+          if (syncError) {
+            console.error('Error syncing rescheduled task to calendar:', syncError);
+          } else {
+            console.log('Rescheduled task synced to calendar:', syncResult);
+          }
+        } catch (syncErr) {
+          console.error('Exception syncing rescheduled task to calendar:', syncErr);
         }
       }
 

--- a/src/hooks/use-tasks.tsx
+++ b/src/hooks/use-tasks.tsx
@@ -29,7 +29,7 @@ export function useTasks() {
   const [error, setError] = useState<Error | null>(null);
   const [syncing, setSyncing] = useState(false);
   const { user } = useAuth();
-  const { operationLoading, createTask, updateTask, deleteTask } = useTaskOperations(user);
+  const { operationLoading, createTask: createTaskOperation, updateTask: updateTaskOperation, deleteTask } = useTaskOperations(user);
 
   // Check if user has Google Calendar connected
   const [isCalendarConnected, setIsCalendarConnected] = useState(false);
@@ -405,8 +405,20 @@ export function useTasks() {
     tasks,
     loading,
     error: error || null,
-    createTask,
-    updateTask,
+    createTask: async (data: Omit<TaskProps, 'id'>) => {
+      const newTask = await createTaskOperation(data);
+      if (newTask) {
+        setTasks(prev => [...prev, newTask]);
+      }
+      return newTask;
+    },
+    updateTask: async (id: string, updates: Partial<TaskProps>) => {
+      const updated = await updateTaskOperation(id, updates);
+      if (updated) {
+        setTasks(prev => prev.map(t => (t.id === updated.id ? updated : t)));
+      }
+      return updated;
+    },
     deleteTask: async (id: string) => {
       // Wrap the deleteTask function to ensure proper state updating
       const result = await deleteTask(id);

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -156,8 +156,10 @@ const TasksContent = ({
       // Set a new timeout to trigger sync after a short delay
       // This debounces multiple rapid changes
       syncTimeoutRef.current = window.setTimeout(() => {
-        console.log('Debounced sync triggered by operation:', lastOperation);
-        synchronizeWithCalendar();
+        if (document.visibilityState === 'visible') {
+          console.log('Debounced sync triggered by operation:', lastOperation);
+          synchronizeWithCalendar();
+        }
         setLastOperation(null);
         syncTimeoutRef.current = null;
       }, 3000); // 3 second debounce


### PR DESCRIPTION
## Summary
- show new tasks immediately without relying on realtime events
- update existing tasks in local state right away
- sync calendar entries when tasks are rescheduled
- avoid background sync when tab is hidden

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684026ae8b7c832ca382cc4d0cc043d6